### PR TITLE
Add nano-scBERT: a minimal, fast, and faithful scBERT implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 [![python >3.6.8](https://img.shields.io/badge/python-3.6.8-brightgreen)](https://www.python.org/) 
 
 ### scBERT as a Large-scale Pretrained Deep Language Model for Cell Type Annotation of Single-cell RNA-seq Data
-Reliable cell type annotation is a prerequisite for downstream analysis of single-cell RNA sequencing data. Existing annotation algorithms typically suffer from improper handling of batch effect, lack of curated marker gene lists, or difficulty in leveraging the latent gene-gene interaction information. Inspired by large scale pretrained langurage models, we present a pretrained deep neural network-based model scBERT (single-cell Bidirectional Encoder Representations from Transformers) to overcome the above challenges. scBERT follows the state-of-the-art paradigm of pre-train and fine-tune in the deep learning field. In the first phase of scBERT, it obtains a general understanding of gene-gene interaction by being pre-trained on huge amounts of unlabeled scRNA-seq data. The pre-trained scBERT can then be used for the cell annotation task of unseen and user-specific scRNA-seq data through supervised fine-tuning. For more information, please refer to [https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1
-        
-        ](https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1
-        
-        )
+Reliable cell type annotation is a prerequisite for downstream analysis of single-cell RNA sequencing data. Existing annotation algorithms typically suffer from improper handling of batch effect, lack of curated marker gene lists, or difficulty in leveraging the latent gene-gene interaction information. Inspired by large scale pretrained langurage models, we present a pretrained deep neural network-based model scBERT (single-cell Bidirectional Encoder Representations from Transformers) to overcome the above challenges. scBERT follows the state-of-the-art paradigm of pre-train and fine-tune in the deep learning field. In the first phase of scBERT, it obtains a general understanding of gene-gene interaction by being pre-trained on huge amounts of unlabeled scRNA-seq data. The pre-trained scBERT can then be used for the cell annotation task of unseen and user-specific scRNA-seq data through supervised fine-tuning. For more information, please refer to [https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1](https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1)
 
 # Related Projects
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 [![python >3.6.8](https://img.shields.io/badge/python-3.6.8-brightgreen)](https://www.python.org/) 
 
 ### scBERT as a Large-scale Pretrained Deep Language Model for Cell Type Annotation of Single-cell RNA-seq Data
-Reliable cell type annotation is a prerequisite for downstream analysis of single-cell RNA sequencing data. Existing annotation algorithms typically suffer from improper handling of batch effect, lack of curated marker gene lists, or difficulty in leveraging the latent gene-gene interaction information. Inspired by large scale pretrained langurage models, we present a pretrained deep neural network-based model scBERT (single-cell Bidirectional Encoder Representations from Transformers) to overcome the above challenges. scBERT follows the state-of-the-art paradigm of pre-train and fine-tune in the deep learning field. In the first phase of scBERT, it obtains a general understanding of gene-gene interaction by being pre-trained on huge amounts of unlabeled scRNA-seq data. The pre-trained scBERT can then be used for the cell annotation task of unseen and user-specific scRNA-seq data through supervised fine-tuning. For more information, please refer to [https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1](https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1)
+Reliable cell type annotation is a prerequisite for downstream analysis of single-cell RNA sequencing data. Existing annotation algorithms typically suffer from improper handling of batch effect, lack of curated marker gene lists, or difficulty in leveraging the latent gene-gene interaction information. Inspired by large scale pretrained langurage models, we present a pretrained deep neural network-based model scBERT (single-cell Bidirectional Encoder Representations from Transformers) to overcome the above challenges. scBERT follows the state-of-the-art paradigm of pre-train and fine-tune in the deep learning field. In the first phase of scBERT, it obtains a general understanding of gene-gene interaction by being pre-trained on huge amounts of unlabeled scRNA-seq data. The pre-trained scBERT can then be used for the cell annotation task of unseen and user-specific scRNA-seq data through supervised fine-tuning. For more information, please refer to [https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1
+        
+        ](https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1
+        
+        )
+
+# Related Projects
+
+- [nano-scBERT](https://github.com/huynguyen250896/nano-scBERT): A lightweight educational reimplementation inspired by scBERT, designed to make the core ideas easier to read, extend, benchmark, and study.
 
 # Install
 
@@ -92,3 +100,5 @@ All rights reserved.
 
 # Citation
 Yang, F., Wang, W., Wang, F. et al. scBERT as a large-scale pretrained deep language model for cell type annotation of single-cell RNA-seq data. Nat Mach Intell (2022). https://doi.org/10.1038/s42256-022-00534-z
+        
+        

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### scBERT as a Large-scale Pretrained Deep Language Model for Cell Type Annotation of Single-cell RNA-seq Data
 Reliable cell type annotation is a prerequisite for downstream analysis of single-cell RNA sequencing data. Existing annotation algorithms typically suffer from improper handling of batch effect, lack of curated marker gene lists, or difficulty in leveraging the latent gene-gene interaction information. Inspired by large scale pretrained langurage models, we present a pretrained deep neural network-based model scBERT (single-cell Bidirectional Encoder Representations from Transformers) to overcome the above challenges. scBERT follows the state-of-the-art paradigm of pre-train and fine-tune in the deep learning field. In the first phase of scBERT, it obtains a general understanding of gene-gene interaction by being pre-trained on huge amounts of unlabeled scRNA-seq data. The pre-trained scBERT can then be used for the cell annotation task of unseen and user-specific scRNA-seq data through supervised fine-tuning. For more information, please refer to [https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1](https://www.biorxiv.org/content/10.1101/2021.12.05.471261v1)
 
-# Related Projects
+# Community Projects
 
 - [nano-scBERT](https://github.com/huynguyen250896/nano-scBERT): A lightweight educational reimplementation inspired by scBERT, designed to make the core ideas easier to read, extend, benchmark, and study.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Reliable cell type annotation is a prerequisite for downstream analysis of singl
 
 # Community Projects
 
-- [nano-scBERT](https://github.com/huynguyen250896/nano-scBERT): A lightweight educational reimplementation inspired by scBERT, designed to make the core ideas easier to read, extend, benchmark, and study.
+[nano-scBERT](https://github.com/huynguyen250896/nano-scBERT): A lightweight educational reimplementation inspired by scBERT, designed to make the core ideas easier to read, extend, benchmark, and study.
 
 # Install
 


### PR DESCRIPTION
Hi everyone,

I recently built **nano-scBERT**, a minimal and faithful reimplementation of scBERT that focuses on reproducibility, maintainability, and performance while preserving the behavior of the original model.

Repository:
https://github.com/huynguyen250896/nano-scBERT

Key features:

* Faithful implementation of the original scBERT architecture and inference pipeline
* Modernized codebase with simplified installation and dependency management
* Cleaner implementation for benchmarking, experimentation, and future extensions
* Designed as a drop-in alternative for users interested in understanding or building upon scBERT

Benchmark highlights:

* **2.5× faster inference** than the original implementation on the Pancreas dataset (4,146 cells)
  - nano-scBERT: 53.71 s (77.19 cells/s)
  - scBERT: 132.64 s (31.25 cells/s)
* Near-perfect embedding reproducibility
  - Mean cosine similarity: 1.0000
  - Median cosine similarity: 1.0000
  - Minimum cosine similarity: 0.9999998
  - Distance correlation: 0.9999998
* Preserves the original representation geometry
  - PCA spectra are nearly identical
  - Local and global cell-cell relationships are maintained
  - Pairwise distance structures closely match the official implementation

I thought it might be useful to include nano-scBERT as a community resource in the README for users looking for a lightweight, reproducible, and actively maintained implementation of scBERT.

This PR only updates the README and does not modify any code, data, checkpoints, or model behavior.

Thank you for your consideration.
